### PR TITLE
Pin django version to 1.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django>=1.9
+Django==1.11
 requests
 psycopg2
 numpy>=1.10


### PR DESCRIPTION
The default Django version installed by pip is now 2.0, which only supports python 3.